### PR TITLE
Domain migrate

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -56,7 +56,7 @@ app.use(
       httpOnly: true,
       secure: production,
       sameSite: "lax",
-      domain: production ? ".kargo.upayan.dev" : undefined,
+      domain: production ? ".kargo.dscvit.com" : undefined,
       maxAge: 7 * 24 * 60 * 60 * 1000, // 1 week
     },
   })


### PR DESCRIPTION
This pull request makes a minor update to the cookie configuration for production environments. The domain for cookies has been changed from `.kargo.upayan.dev` to `.kargo.dscvit.com`.